### PR TITLE
Header menu alignment

### DIFF
--- a/wcm17.css
+++ b/wcm17.css
@@ -365,6 +365,15 @@ Ticket for Mobile
     max-width: 100%;
 }
 
+/* Header & Menu */
+.site-branding {
+    text-align: center;
+}
+
+ul#top-menu {
+    text-align: center;
+}
+
 /* Organizers */
 .wcorg-organizers {
     text-align: center;


### PR DESCRIPTION
Both are centre aligned as currently it looks unbalanced as right side
looks empty. Will look like the attached screenshot.
![header_menu](https://cloud.githubusercontent.com/assets/1039236/22511761/adee0558-e8bc-11e6-88a7-44d975adefca.png)

