### PR TITLE
Remove width for mobile device

### DIFF
--- a/wcm18.css
+++ b/wcm18.css
@@ -3308,6 +3308,6 @@ img.emoji, img.wp-smiley {
 
 @media screen and (max-width: 720px) {
 	#primary {
-		max-width: 100%;
+		max-width: 95%;
 	}
 }

--- a/wcm18.css
+++ b/wcm18.css
@@ -3304,3 +3304,10 @@ img.emoji, img.wp-smiley {
 		padding: 1.5rem 2rem;
 	}
 }
+
+
+@media screen and (max-width: 720px) {
+	#primary {
+		max-width: 100%;
+	}
+}


### PR DESCRIPTION
In mobile device, the width was very small so it was very hard to read the content

Before:
![image](https://user-images.githubusercontent.com/22215595/34539616-3554847a-f0f7-11e7-9328-05f520d58026.png)


After:
![image](https://user-images.githubusercontent.com/22215595/34539604-290a5406-f0f7-11e7-8ba0-fd32e83f2c0d.png)
