### PR TITLE
Blockquote overlapping design fixed

### DIFF
--- a/wcm18.css
+++ b/wcm18.css
@@ -521,3 +521,15 @@ blockquote > p {
 	background-color: #c74419;
 }
 /*site-info generator*/
+
+/* Blockquote Design Fixed start */
+blockquote::before{
+	font-size: 3rem;
+    line-height: 100%;
+}
+blockquote > p:nth-child(1){
+margin: -30px auto auto 20px;
+    line-height: 130%;
+}
+/* Blockquote Design Fixed end */
+


### PR DESCRIPTION
Qode added from line number 525 - 534
/* Blockquote Design Fixed start */
blockquote::before{
	font-size: 3rem;
    line-height: 100%;
}
blockquote > p:nth-child(1){
margin: -30px auto auto 20px;
    line-height: 130%;
}
/* Blockquote Design Fixed end */

## Description
<!-- Please describe your changes -->

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- What types of changes does your code introduce?  -->
<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Breaking change (fix or feature that would cause existing functionality to not work as expected) -->

## Checklist:
- [ ] My code is tested.
- [ ] My code follows the WordPress code style.
- [ ] My code follows has proper inline documentation.