### PR TITLE
Remove margin-left from site-info

### DIFF
--- a/wcm19.css
+++ b/wcm19.css
@@ -3991,7 +3991,7 @@ Sponsors
     padding: 0.7em 0 0;
     width: 100%; }
   .social-navigation + .site-info {
-    margin-left: 6%; }
+    margin-left: 0; }
   .site-info .sep {
     margin: 0 0.5em;
     display: inline;


### PR DESCRIPTION
## Description
The margin-left property given to `.social-navigation + .site-info` class is causing overflow.
Hence making it 0 will fix the horizontal scroll issue.

## How Has This Been Tested?
Tested by making changes in Inspect Element.

## Screenshots (jpeg or gifs if applicable):

## Types of changes
<!-- Bug fix (non-breaking change which fixes an issue) -->

## Checklist:
- [✓] My code is tested.
- [✓] My code follows the WordPress code style.
- [✓] My code follows has proper inline documentation.