### PR TITLE
Fixed for subscribe form - In response message link was not visible

### DIFF
--- a/wcm19.css
+++ b/wcm19.css
@@ -1576,6 +1576,11 @@ a:hover .nav-title {
   color: #000;
   text-decoration: underline; }
 
+/* Fixed for subscribe form - In response message link was not visible */
+.widget.widget_blog_subscription .error a {
+  color: #fff;
+}
+
 /* Fixes linked images */
 .entry-content a img,
 .widget a img {


### PR DESCRIPTION
## Description
Fixed for subscribe form - In response message link was not visible

## How Has This Been Tested?
Tested by making changes in Inspect Element.

## Screenshots (jpeg or gifs if applicable):
**Before:**
![link-not-visible](https://user-images.githubusercontent.com/26963837/64539837-d796e600-d33c-11e9-9a90-bc04c0dc2989.png)

**After:**
![image](https://user-images.githubusercontent.com/26963837/64539992-1a58be00-d33d-11e9-97e7-45c663707696.png)


## Types of changes
CSS tweak

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.